### PR TITLE
Ensure object id for created DynaObjects

### DIFF
--- a/src/main/java/info/kfgodel/dyna/api/DynaObject.java
+++ b/src/main/java/info/kfgodel/dyna/api/DynaObject.java
@@ -11,6 +11,18 @@ import java.util.Map;
 public interface DynaObject {
 
   /**
+   * Property under which the object id is stored as state
+   */
+  String OBJECT_ID_PROPERTY = "objectId";
+
+  /**
+   * Returns the internal object id that uniquely identifies this instance accross all types.<br>
+   * Two objects are considered teh same if they have the equal object id, even if they are not the same instance.<br>
+   * @return The generated ID that is shared between instances that represents the same object
+   */
+  String getObjectId();
+
+  /**
    * Returns the internal state of this object as a map of properties that can be modified.<br>
    * @return Tha map that represents this object
    */

--- a/src/main/java/info/kfgodel/dyna/impl/creator/DynaObjectCreator.java
+++ b/src/main/java/info/kfgodel/dyna/impl/creator/DynaObjectCreator.java
@@ -1,11 +1,13 @@
 package info.kfgodel.dyna.impl.creator;
 
+import info.kfgodel.dyna.api.DynaObject;
 import info.kfgodel.dyna.api.ObjectCreator;
 import info.kfgodel.dyna.api.environment.EnvironmentDependent;
 import info.kfgodel.dyna.api.exceptions.DynaWorldException;
 import info.kfgodel.dyna.impl.instantiator.DynaTypeInstantiator;
 
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * This type defines the object creator following the same rules as the rest of the creatable objects
@@ -16,6 +18,10 @@ public interface DynaObjectCreator extends ObjectCreator, EnvironmentDependent {
 
   @Override
   default <T> T create(Class<T> expectedType, Map<String, Object> initialState) throws DynaWorldException{
+    if(!initialState.containsKey(DynaObject.OBJECT_ID_PROPERTY)){
+      // Ensure every created object has a unique id
+      initialState.put(DynaObject.OBJECT_ID_PROPERTY, UUID.randomUUID().toString());
+    }
     DynaTypeInstantiator instantiator = environment().provide(DynaTypeInstantiator.class);
     return instantiator.instantiate(expectedType, initialState);
   }

--- a/src/test/java/info/kfgodel/dyna/creator/ObjectCreatorTest.java
+++ b/src/test/java/info/kfgodel/dyna/creator/ObjectCreatorTest.java
@@ -2,12 +2,15 @@ package info.kfgodel.dyna.creator;
 
 import ar.com.dgarcia.javaspec.api.JavaSpec;
 import ar.com.dgarcia.javaspec.api.JavaSpecRunner;
+import com.google.common.collect.ImmutableMap;
 import info.kfgodel.dyna.WorldTestContext;
 import info.kfgodel.dyna.api.DynaObject;
 import info.kfgodel.dyna.api.environment.EnvironmentDependent;
 import info.kfgodel.dyna.impl.DefaultEnvironment;
 import info.kfgodel.dyna.testobjects.SimpleTestObject;
 import org.junit.runner.RunWith;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,9 +41,20 @@ public class ObjectCreatorTest extends JavaSpec<WorldTestContext> {
           assertThat(created).isInstanceOf(DynaObject.class);
         });
 
+        it("gives dyna objects a unique id of 36 characters",()->{
+          DynaObject created = (DynaObject) test().creator().create(SimpleTestObject.class);
+          assertThat(created.getObjectId()).hasSize(36);
+        });
+
+        it("keeps existing id if defined in the initial state",()->{
+          Map<String, Object> initialState = ImmutableMap.of(DynaObject.OBJECT_ID_PROPERTY,"an id");
+          DynaObject created = (DynaObject) test().creator().create(SimpleTestObject.class, initialState);
+          assertThat(created.getObjectId()).isEqualTo("an id");
+        });
+
         it("gives dyna objects access to their internal state",()->{
           DynaObject created = (DynaObject) test().creator().create(SimpleTestObject.class);
-          assertThat(created.getInternalState()).isEmpty();
+          assertThat(created.getInternalState()).containsKeys(DynaObject.OBJECT_ID_PROPERTY);
         });
 
         it("allows created objects to depend on the environment",()->{

--- a/src/test/java/info/kfgodel/dyna/dyna/AccessOwnStateTest.java
+++ b/src/test/java/info/kfgodel/dyna/dyna/AccessOwnStateTest.java
@@ -19,10 +19,10 @@ public class AccessOwnStateTest extends JavaSpec<WorldTestContext> {
       test().objectWithState(() -> DefaultEnvironment.create().creator().create(SelfStateObject.class));
 
       it("can instrospect its own state map", () -> {
-        assertThat(test().objectWithState().getPropertyCount()).isEqualTo(0);
+        assertThat(test().objectWithState().getPropertyCount()).isEqualTo(1);
 
         test().objectWithState().setName("Pepe");
-        assertThat(test().objectWithState().getPropertyCount()).isEqualTo(1);
+        assertThat(test().objectWithState().getPropertyCount()).isEqualTo(2);
       });
 
 


### PR DESCRIPTION
Adds a unique Id as part of the created object state